### PR TITLE
feat: added use native driver configurable support

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -67,7 +67,8 @@ export default class Carousel extends Component {
         useScrollView: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
         vertical: PropTypes.bool,
         onBeforeSnapToItem: PropTypes.func,
-        onSnapToItem: PropTypes.func
+        onSnapToItem: PropTypes.func,
+        useNativeDriver: PropTypes.bool
     };
 
     static defaultProps = {
@@ -99,7 +100,8 @@ export default class Carousel extends Component {
         shouldOptimizeUpdates: true,
         swipeThreshold: 20,
         useScrollView: !AnimatedFlatList,
-        vertical: false
+        vertical: false,
+        useNativeDriver: true
     }
 
     constructor (props) {
@@ -295,7 +297,7 @@ export default class Carousel extends Component {
       // Native driver for scroll events
       const scrollEventConfig = {
         listener: this._onScroll,
-        useNativeDriver: true,
+        useNativeDriver: props.useNativeDriver
       };
       this._scrollPos = new Animated.Value(0);
       const argMapping = props.vertical
@@ -634,7 +636,7 @@ export default class Carousel extends Component {
 
         const animationCommonOptions = {
             isInteraction: false,
-            useNativeDriver: true,
+            useNativeDriver: this.props.useNativeDriver,
             ...activeAnimationOptions,
             toValue: toValue
         };

--- a/src/parallaximage/ParallaxImage.js
+++ b/src/parallaximage/ParallaxImage.js
@@ -28,7 +28,8 @@ export default class ParallaxImage extends Component {
         AnimatedImageComponent: PropTypes.oneOfType([
             PropTypes.func,
             PropTypes.object
-        ])
+        ]),
+        useNativeDriver: PropTypes.bool
     };
 
     static defaultProps = {
@@ -37,7 +38,8 @@ export default class ParallaxImage extends Component {
         parallaxFactor: 0.3,
         showSpinner: true,
         spinnerColor: 'rgba(0, 0, 0, 0.4)',
-        AnimatedImageComponent: Animated.Image
+        AnimatedImageComponent: Animated.Image,
+        useNativeDriver: true
     }
 
     constructor (props) {
@@ -124,7 +126,7 @@ export default class ParallaxImage extends Component {
             duration: fadeDuration,
             easing: Easing.out(Easing.quad),
             isInteraction: false,
-            useNativeDriver: true
+            useNativeDriver: this.props.useNativeDriver
         }).start(() => {
             this.setState({ status: 3 });
         });


### PR DESCRIPTION

**Issue link:** https://github.com/meliorence/react-native-snap-carousel/issues/1011

**Issue overview:** Currently their is no provision to enable/disable useNativeDriver for react native snap carousal. For carousal animations useNativeDriver is set to true i.e they run on UI thread by default. We encountered some crashes related to Animated node that occurred only on Android 12 devices and after digging into it we get to know it is related to useNativeDriver set to true for carousal animations. Also their is an open issue in react-native related to this crash: https://github.com/facebook/react-native/issues/33375. So we added a patch in react-native-snap-carousal library for disabling useNativeDriver for devices having Android 12 and that reduces the crash rate for that crash with very few instances now. We have been using this for almost a year and haven't faced any issue with our app exposed to more than 20 million users. So we though of adding support for enable/disable useNativeDriver for react-native-snap-carousal as a exposed prop.